### PR TITLE
fix(config): use default for job name, error on empty default

### DIFF
--- a/cloudflare/cloudflare.go
+++ b/cloudflare/cloudflare.go
@@ -32,7 +32,7 @@ func NewClient(cfg *config.Config) (*Client, error) {
 
 // getARecords is a function of type cloudflare client which takes a context and returns all A records in a zone
 func (c *Client) getARecords(ctx context.Context) ([]internaltypes.DNSRecord, error) {
-	records, _, err := c.api.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneId), cloudflare.ListDNSRecordsParams{
+	records, _, err := c.api.ListDNSRecords(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneID), cloudflare.ListDNSRecordsParams{
 		Name: c.config.DNSRecordName,
 		Type: "A",
 	})
@@ -69,7 +69,7 @@ func (c *Client) CreateARecord(ctx context.Context, target string) error {
 		TTL:     0,
 	}
 
-	_, err := c.api.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneId), record)
+	_, err := c.api.CreateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneID), record)
 	if err != nil {
 		return fmt.Errorf("Failed to create A record %w", err)
 	}
@@ -91,7 +91,7 @@ func (c *Client) UpdateARecord(ctx context.Context, recordID, target string) err
 		TTL:     0,
 	}
 
-	_, err := c.api.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneId), record)
+	_, err := c.api.UpdateDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneID), record)
 	if err != nil {
 		return fmt.Errorf("Unable to update DNS Record: %w", err)
 	}
@@ -103,7 +103,7 @@ func (c *Client) UpdateARecord(ctx context.Context, recordID, target string) err
 
 // DeleteARecord is a function of type cloudflare client which takes a context and a record ID as parameters and returns an error
 func (c *Client) DeleteARecord(ctx context.Context, recordID string) error {
-	err := c.api.DeleteDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneId), recordID)
+	err := c.api.DeleteDNSRecord(ctx, cloudflare.ZoneIdentifier(c.config.CloudflareZoneID), recordID)
 	if err != nil {
 		return fmt.Errorf("Failed to delete A record: %w", err)
 	}

--- a/cloudflare/cloudflare_test.go
+++ b/cloudflare/cloudflare_test.go
@@ -70,7 +70,7 @@ func TestCreateARecordValidation(t *testing.T) {
 			target: "1.1.1.1",
 			config: &config.Config{
 				DNSRecordName:    "test.example.com",
-				CloudflareZoneId: "test-zone-id",
+				CloudflareZoneID: "test-zone-id",
 				CloudflareToken:  "test-token",
 			},
 			expectValid: true,
@@ -80,7 +80,7 @@ func TestCreateARecordValidation(t *testing.T) {
 			target: "",
 			config: &config.Config{
 				DNSRecordName:    "test.example.com",
-				CloudflareZoneId: "test-zone-id",
+				CloudflareZoneID: "test-zone-id",
 				CloudflareToken:  "test-token",
 			},
 			expectValid: false,
@@ -90,7 +90,7 @@ func TestCreateARecordValidation(t *testing.T) {
 			target: "1.1.1.1",
 			config: &config.Config{
 				DNSRecordName:    "",
-				CloudflareZoneId: "test-zone-id",
+				CloudflareZoneID: "test-zone-id",
 				CloudflareToken:  "test-token",
 			},
 			expectValid: false,
@@ -102,7 +102,7 @@ func TestCreateARecordValidation(t *testing.T) {
 			// Test input validation without making API calls
 			isValid := tt.target != "" &&
 				tt.config.DNSRecordName != "" &&
-				tt.config.CloudflareZoneId != "" &&
+				tt.config.CloudflareZoneID != "" &&
 				tt.config.CloudflareToken != ""
 
 			if isValid != tt.expectValid {
@@ -191,7 +191,7 @@ func TestNewClient(t *testing.T) {
 			name: "valid configuration",
 			config: &config.Config{
 				CloudflareToken:  "valid-token",
-				CloudflareZoneId: "valid-zone-id",
+				CloudflareZoneID: "valid-zone-id",
 				DNSRecordName:    "test.example.com",
 			},
 			expectError: false,
@@ -200,7 +200,7 @@ func TestNewClient(t *testing.T) {
 			name: "empty token",
 			config: &config.Config{
 				CloudflareToken:  "",
-				CloudflareZoneId: "valid-zone-id",
+				CloudflareZoneID: "valid-zone-id",
 				DNSRecordName:    "test.example.com",
 			},
 			expectError: true,

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,5 @@
+// Package config contains the types and support functions for configuring
+// startup of the application.
 package config
 
 import (
@@ -13,7 +15,7 @@ type Config struct {
 
 	// Cloudflare configuration
 	CloudflareToken  string
-	CloudflareZoneId string
+	CloudflareZoneID string
 
 	// Application configuration
 	TraefikJobName string // Name of the Traefik job in the Nomad cluster that we are watching
@@ -36,23 +38,31 @@ func LoadConfig() (*Config, error) {
 		NomadAddress:     getEnvOrDefault("NOMAD_ADDR", "http://localhost:8686"), // This could be nomad.service.consul in a service-discovery cluster.
 		NomadToken:       os.Getenv("NOMAD_TOKEN"),
 		CloudflareToken:  os.Getenv("CLOUDFLARE_API_TOKEN"),
-		CloudflareZoneId: os.Getenv("CLOUDFLARE_ZONE_ID"),
-		TraefikJobName:   os.Getenv("TRAEFIK_JOB_NAME"),
+		CloudflareZoneID: os.Getenv("CLOUDFLARE_ZONE_ID"),
+		TraefikJobName:   getEnvOrDefault("TRAEFIK_JOB_NAME", "ingress"),
 		DNSRecordName:    os.Getenv("DNS_RECORD_NAME"),
 		LogLevel:         getEnvOrDefault("LOG_LEVEL", "info"),
 	}
 
 	// Check if required values are not set
 	if config.CloudflareToken == "" {
-		return nil, fmt.Errorf("CLOUDFLARE_API_TOKEN is not set and is required.")
+		return nil, fmt.Errorf("variable CLOUDFLARE_API_TOKEN is not set and is required")
 	}
 
-	if config.CloudflareZoneId == "" {
-		return nil, fmt.Errorf("CLOUDFLARE_ZONE_ID is not set and is required.")
+	if config.CloudflareZoneID == "" {
+		return nil, fmt.Errorf("variable CLOUDFLARE_ZONE_ID is not set and is required")
+	}
+
+	if config.TraefikJobName == "" {
+		return nil, fmt.Errorf("variable TRAEFIK_JOB_NAME is not set and is required")
+	}
+
+	if config.DNSRecordName == "" {
+		return nil, fmt.Errorf("variable DNS_RECORD_NAME is not set and is required")
 	}
 
 	if config.NomadToken == "" {
-		return nil, fmt.Errorf("Nomad token is not set and is required.")
+		return nil, fmt.Errorf("nomad token is not set and is required")
 	}
 
 	return config, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -87,6 +87,7 @@ func TestLoadConfig(t *testing.T) {
 				"CLOUDFLARE_API_TOKEN": "test_token",
 				"CLOUDFLARE_ZONE_ID":   "test_zone_id",
 				"NOMAD_TOKEN":          "test_nomad_token",
+				"DNS_RECORD_NAME":      "test.example.com",
 			},
 			expectError: false,
 		},
@@ -95,9 +96,10 @@ func TestLoadConfig(t *testing.T) {
 			envVars: map[string]string{
 				"CLOUDFLARE_ZONE_ID": "test_zone_id",
 				"NOMAD_TOKEN":        "test_nomad_token",
+				"DNS_RECORD_NAME":    "test.example.com",
 			},
 			expectError: true,
-			errorMsg:    "CLOUDFLARE_API_TOKEN is not set and is required.",
+			errorMsg:    "variable CLOUDFLARE_API_TOKEN is not set and is required",
 		},
 		{
 			name: "Missing cloudflare zone id is an invalid configuration since there is no default",
@@ -106,16 +108,17 @@ func TestLoadConfig(t *testing.T) {
 				"NOMAD_TOKEN":          "test_nomad_token",
 			},
 			expectError: true,
-			errorMsg:    "CLOUDFLARE_ZONE_ID is not set and is required.",
+			errorMsg:    "variable CLOUDFLARE_ZONE_ID is not set and is required",
 		},
 		{
 			name: "Missing Nomad token is an invalid configuration since there is no default.",
 			envVars: map[string]string{
 				"CLOUDFLARE_API_TOKEN": "test_token",
 				"CLOUDFLARE_ZONE_ID":   "test_zone_id",
+				"DNS_RECORD_NAME":      "test.example.com",
 			},
 			expectError: true,
-			errorMsg:    "Nomad token is not set and is required.",
+			errorMsg:    "nomad token is not set and is required",
 		},
 	}
 
@@ -175,7 +178,7 @@ func TestLoadConfig(t *testing.T) {
 			if config.CloudflareToken == "" {
 				t.Error("CloudflareToken should be set")
 			}
-			if config.CloudflareZoneId == "" {
+			if config.CloudflareZoneID == "" {
 				t.Error("CloudflareZoneId should be set")
 			}
 			if config.NomadToken == "" {
@@ -213,6 +216,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 	os.Setenv("CLOUDFLARE_API_TOKEN", "test_token")
 	os.Setenv("CLOUDFLARE_ZONE_ID", "test_zone_id")
 	os.Setenv("NOMAD_TOKEN", "test_nomad_token")
+	os.Setenv("DNS_RECORD_NAME", "test.example.com")
 
 	config, err := LoadConfig()
 	if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -41,14 +41,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
-github.com/hashicorp/nomad/api v0.0.0-20250806174037-6563d0ec3ca8 h1:rRsBUKlcFM8fw+xWSeJ4dhqUHtl8Az7WvTDxXDvtS3o=
-github.com/hashicorp/nomad/api v0.0.0-20250806174037-6563d0ec3ca8/go.mod h1:y4olHzVXiQolzyk6QD/gqJxQTnnchlTf/QtczFFKwOI=
-github.com/hashicorp/nomad/api v0.0.0-20250807124441-79bf6198338f h1:qYwpV4R9h7FTSkmMho1MbgliPaUFnX5SpVe1S47ackA=
-github.com/hashicorp/nomad/api v0.0.0-20250807124441-79bf6198338f/go.mod h1:y4olHzVXiQolzyk6QD/gqJxQTnnchlTf/QtczFFKwOI=
-github.com/hashicorp/nomad/api v0.0.0-20250807210333-b6f90d0562ae h1:16+yVDUdeZ2lVk6uXFDpHP4zZbQKL9rKqMmNpnDVKbs=
-github.com/hashicorp/nomad/api v0.0.0-20250807210333-b6f90d0562ae/go.mod h1:y4olHzVXiQolzyk6QD/gqJxQTnnchlTf/QtczFFKwOI=
-github.com/hashicorp/nomad/api v0.0.0-20250808195558-d305f3201760 h1:pQdXFZx40oJpStTo3gIW9XCyEQMuag5pPNLuYfKyeJw=
-github.com/hashicorp/nomad/api v0.0.0-20250808195558-d305f3201760/go.mod h1:y4olHzVXiQolzyk6QD/gqJxQTnnchlTf/QtczFFKwOI=
 github.com/hashicorp/nomad/api v0.0.0-20250811131312-7964c5ab18e1 h1:fy26WEXcxESawJQ1OI2DsBZ8JyQorC7oDNZ349ZYu68=
 github.com/hashicorp/nomad/api v0.0.0-20250811131312-7964c5ab18e1/go.mod h1:y4olHzVXiQolzyk6QD/gqJxQTnnchlTf/QtczFFKwOI=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=


### PR DESCRIPTION
This winds forward to the last event in the stream, so that we do not have to parse through the entire history of events at startup.

fix(nomad): start from the last event in the stream
refactor: rename symbol CloudflareZoneId to CloudflareZoneID
style: change error message format to comply with go-critic